### PR TITLE
Reset sf_value on read

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from distutils.core import setup
 
 setup(
     name='pysunspec2',
-    version='1.0.4',
+    version='1.0.5',
     description='Python SunSpec Tools',
     author='SunSpec Alliance',
     author_email='support@sunspec.org',

--- a/sunspec2/device.py
+++ b/sunspec2/device.py
@@ -301,9 +301,9 @@ class Point(object):
             if len(data) < mb_len * 2:
                 return len(data)
             self.set_value(self.info.data_to(data[:mb_len * 2]), computed=computed, dirty=dirty)
+            self.sf_value = None
             if not self.info.is_impl(self.value):
                 self.set_value(None)
-                self.sf_value = None
         except Exception as e:
             self.model.add_error('Error setting value for %s: %s' % (self.pdef[mdef.NAME], str(e)))
         return mb_len


### PR DESCRIPTION
This PR is a possible fix for #42.

On Point.set_mb (which is called by read()) the value of self.sf_value is reset to None.