### PR TITLE
Add timeout param to tcp client connect

### DIFF
--- a/sunspec2/modbus/client.py
+++ b/sunspec2/modbus/client.py
@@ -304,8 +304,8 @@ class SunSpecModbusClientDeviceTCP(SunSpecModbusClientDevice):
         if self.client is None:
             raise SunSpecModbusClientError('No modbus tcp client set for device')
 
-    def connect(self):
-        self.client.connect()
+    def connect(self, timeout=None):
+        self.client.connect(timeout)
 
     def disconnect(self):
         self.client.disconnect()


### PR DESCRIPTION
Adds an optional timeout param to the client connect method, this will make it possible for example to have a short timeout for connection and a longer timeout for regular read/write. The internal modbus client already supports this so this is a very small change.