### PR TITLE
Migrate setup.py from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
   All Rights Reserved
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='pysunspec2',


### PR DESCRIPTION
distutils is deprecated and will be removed in python 3.12
( https://peps.python.org/pep-0632/ )