### PR TITLE
[ISSUE #72] Round computed value to remove floating pt error

### DIFF
--- a/sunspec2/device.py
+++ b/sunspec2/device.py
@@ -220,7 +220,7 @@ class Point(object):
             if self.sf_value:
                 sfv = self.sf_value
                 if sfv:
-                    v = v * math.pow(10, sfv)
+                    v = round(v * math.pow(10, sfv), -1 * sfv)
         return v
 
     def set_value(self, data=None, computed=False, dirty=None):

--- a/sunspec2/tests/test_device.py
+++ b/sunspec2/tests/test_device.py
@@ -456,9 +456,9 @@ class TestPoint:
         setattr(m, 'points', points)
         p2 = device.Point(p_def, model=m)
         p2.sf_value = -2
-        p2.cvalue = 1.16
-        assert p2.cvalue == 1.16
-        assert p2.value == 116
+        p2.cvalue = 1.38
+        assert p2.cvalue == 1.38
+        assert p2.value == 138
 
         # test static true
         p_def2 = {


### PR DESCRIPTION
When computing a scaled value, round the output to remove floating point error. See Issue #72