### PR TITLE
Provide symbols info in model def

### DIFF
--- a/sunspec2/tests/test_smdx.py
+++ b/sunspec2/tests/test_smdx.py
@@ -32,6 +32,21 @@ def test_from_smdx_file():
     assert smdx.from_smdx_file('sunspec2/models/smdx/smdx_00304.xml') == smdx_304
 
 
+def test_from_smdx_file_symbols():
+    mdef = smdx.from_smdx_file('sunspec2/models/smdx/smdx_00803.xml')
+    for point_def in mdef["group"]["groups"][0]["points"]:
+        if point_def["name"] != "StrSt":
+            continue
+        symbol = point_def["symbols"][1]
+        assert symbol["name"] == "CONTACTOR_STATUS"
+        assert symbol["label"] == "Contactor Status"
+        assert symbol["desc"].startswith("String")
+        assert symbol["detail"]
+        break
+    else:
+        pytest.fail("Point not found")
+
+
 def test_from_smdx():
     tree = ET.parse('sunspec2/models/smdx/smdx_00304.xml')
     root = tree.getroot()


### PR DESCRIPTION
The dict provided by smdx.from_smdx didn't include all the info provided in the SMDX for symbols, and instead just contained name & value.

Going through all the smdx string/symbols elements to collect info, and assigning that to matching symbol definitions.

This is a symbol before:
```
        "symbols": [
          {
            "name": "IEEE_1547",
            "value": 0
          },
```
and after:
```
        "symbols": [
          {
            "name": "IEEE_1547",
            "value": 0,
            "label": "IEEE 1547 (default)",
            "desc": "'IEEE 1547' is the most common inverter compliance setting."
          },
```

Most SMDX files do not provide additional symbol info and are therefore not affected.