### PR TITLE
Addition of Function Code 06 (Single Register Write) Operations

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,3 +1,3 @@
 {
-  "contributors": ["bobfox", "shelcrow"]
+  "contributors": ["bobfox", "shelcrow", "dersecure"]
 }

--- a/README.rst
+++ b/README.rst
@@ -37,13 +37,13 @@ Installing using pip:
 
 Installation using pip installs the models as well
 
-Installing from the setup.py file (deprecated):
+Installing from the setup.py file:
 
- C:\> python setup.py install
+ C:\pysunspec2> python -m pip install .
  
 or if the python path isn't configured:
  
- C:\> c:\\Python37\\python.exe setup.py install
+ C:\pysunspec2> c:\\Python37\\python.exe setup.py install
 
 Note: To install the models while cloning the repository, make sure to add the recursive tag:
 

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ pySunSpec2
 Overview
 ========
 pySunSpec is a python package that provides objects and applications that support interaction with SunSpec compliant
-devices and documents. pySunSpec runs in most environments that support Python and is tested on Windows 7 and
-Windows 10.
+devices and documents. pySunSpec runs in most environments that support Python and is tested on Windows 7, Windows 10,
+and Windows 11.
 
 This is the next generation of pySunSpec tools. It supports all SunSpec infomation model definitions and formats including smdx and
 json. The Python objects used for interacting with devices have some differences from version 1 and it is not backward
@@ -39,11 +39,11 @@ Installation using pip installs the models as well
 
 Installing from the setup.py file:
 
- C:\pysunspec2> python -m pip install .
+ C:\\pysunspec2> python -m pip install .
  
 or if the python path isn't configured:
  
- C:\pysunspec2> c:\\Python37\\python.exe setup.py install
+ C:\\pysunspec2> c:\\Python37\\python.exe -m pip install .
 
 Note: To install the models while cloning the repository, make sure to add the recursive tag:
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from distutils.core import setup
 
 setup(
     name='pysunspec2',
-    version='1.0.9',
+    version='1.1.0',
     description='Python SunSpec Tools',
     author='SunSpec Alliance',
     author_email='support@sunspec.org',

--- a/sunspec2/modbus/client.py
+++ b/sunspec2/modbus/client.py
@@ -308,7 +308,7 @@ class SunSpecModbusClientDevice(device.Device):
 
 class SunSpecModbusClientDeviceTCP(SunSpecModbusClientDevice):
     def __init__(self, slave_id=1, ipaddr='127.0.0.1', ipport=502, timeout=None, ctx=None, trace_func=None,
-                 max_count=modbus_client.REQ_COUNT_MAX, max_write_count=modbus_client.REQ_WRITE_COUNT_MAX, test=False,
+                 max_count=modbus_client.REQ_COUNT_MAX, max_write_count=modbus_client.REQ_WRITE_COUNT_MAX,
                  model_class=SunSpecModbusClientModel):
         SunSpecModbusClientDevice.__init__(self, model_class=model_class)
         self.slave_id = slave_id
@@ -324,7 +324,8 @@ class SunSpecModbusClientDeviceTCP(SunSpecModbusClientDevice):
         self.client = modbus_client.ModbusClientTCP(slave_id=slave_id, ipaddr=ipaddr, ipport=ipport, timeout=timeout,
                                                     ctx=ctx, trace_func=trace_func,
                                                     max_count=modbus_client.REQ_COUNT_MAX,
-                                                    max_write_count=modbus_client.REQ_WRITE_COUNT_MAX, test=test)
+                                                    max_write_count=modbus_client.REQ_WRITE_COUNT_MAX)
+
         if self.client is None:
             raise SunSpecModbusClientError('No modbus tcp client set for device')
 
@@ -421,7 +422,7 @@ class SunSpecModbusClientDeviceRTU(SunSpecModbusClientDevice):
             Byte string containing register contents.
         """
 
-        return self.client.read(self.slave_id, addr, count, op=op, trace_func=self.trace_func, max_count=self.max_count)
+        return self.client.read(self.slave_id, addr, count, op=op, max_count=self.max_count)
 
     def write(self, addr, data):
         """Write Modbus device registers.
@@ -432,5 +433,4 @@ class SunSpecModbusClientDeviceRTU(SunSpecModbusClientDevice):
                 Byte string containing register contents.
         """
 
-        return self.client.write(self.slave_id, addr, data, trace_func=self.trace_func,
-                                 max_write_count=self.max_write_count)
+        return self.client.write(self.slave_id, addr, data, max_write_count=self.max_write_count)


### PR DESCRIPTION
This is working well for the TCP client.  

The `_write_single()` function for the RTU client will need to be debugged with a physical device.  It's bypassed for now. 