### PR TITLE
Declare pyserial as a runtime dependency (imported unconditionally by modbus.py)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,11 @@ setup(
     },
     scripts=['scripts/suns.py'],
     python_requires='>=3.5',
+    # pyserial is imported unconditionally by sunspec2/modbus/modbus.py, which
+    # is imported by sunspec2/modbus/client.py -- so it is required for any use
+    # of the Modbus client (TCP or RTU), not optional. It is kept in
+    # extras_require['serial'] below too for backwards compatibility.
+    install_requires=['pyserial>=3.5'],
     extras_require={
       'serial': ['pyserial'],
       'excel': ['openpyxl'],


### PR DESCRIPTION
## Problem

`sunspec2/modbus/modbus.py` imports `serial` at module top level:

```python
import serial
```

and `sunspec2/modbus/client.py` imports `sunspec2.modbus.modbus`, so importing the SunSpec Modbus client pulls in `pyserial` regardless of whether you use a TCP or an RTU connection.

However, `setup.py` declares no `install_requires`, and `pyserial` appears only under `extras_require['serial']`. So a plain `pip install pysunspec2` does not install pyserial, and using the Modbus client then fails:

```python
>>> import sunspec2.modbus.client
ModuleNotFoundError: No module named 'serial'
```

This bites any downstream package that depends on `pysunspec2` and drives the Modbus client without knowing to request the `[serial]` extra — even for TCP-only usage.

## Fix

Add `pyserial>=3.5` to `install_requires` so it is always installed alongside `pysunspec2`. The `'serial'` extra is kept for backwards compatibility (now redundant).

`pyserial>=3.5` matches the pin already in the repo's `requirements.txt`.
