### PR TITLE
Fix: repeating group length inference must include nested subgroup points

### DIFF
--- a/sunspec2/device.py
+++ b/sunspec2/device.py
@@ -564,7 +564,7 @@ class Group(object):
                 gdata = self._group_data(data=data, name=gdef[mdef.NAME], index=0)
                 g = self.group_class(gdef=gdef, model=self.model, model_offset=model_offset, data=gdata,
                                      data_offset=data_offset, index=1)
-                group_points_len = g.points_len
+                group_points_len = g.len
                 # count is (model.len - non-repeating points) / group_points_len
                 # (ID and L points are not included in model length)
                 # TODO: investigate if this only works when there's a single group in the model

--- a/sunspec2/tests/test_device.py
+++ b/sunspec2/tests/test_device.py
@@ -1698,6 +1698,82 @@ class TestGroup:
         assert len(groups) == 3
         assert len(groups[0].groups['Pt']) == 4
 
+    def test__init_repeating_group_legacy_count_nested_group(self):
+        # regression test for a repeating group (Crv) that itself contains a nested
+        # repeating group (Pt), as in model 705, when the count must be inferred from
+        # the model length rather than read directly from the count point (count == 0).
+        # each Crv instance is 10 registers of its own points plus 2 Pt points of 2
+        # registers each = 14 registers per curve; two curves make 28 repeating registers.
+        gdef_crv = {
+            "count": "NCrv",
+            "name": "Crv",
+            "groups": [
+                {
+                    "count": "NPt",
+                    "name": "Pt",
+                    "points": [
+                        {"name": "V", "type": "uint16"},
+                        {"name": "Var", "type": "int16"},
+                    ],
+                    "type": "group",
+                }
+            ],
+            "points": [
+                {"name": "ActPt", "type": "uint16"},
+                {"name": "DeptRef", "type": "enum16"},
+                {"name": "Pri", "type": "enum16"},
+                {"name": "VRef", "type": "uint16"},
+                {"name": "VRefAuto", "type": "enum16"},
+                {"name": "VRefAutoEna", "type": "enum16"},
+                {"name": "VRefAutoTms", "type": "uint16"},
+                {"name": "RspTms", "type": "uint32"},
+                {"name": "ReadOnly", "type": "enum16"},
+            ],
+            "type": "group",
+        }
+
+        p_ncrv = device.Point({"name": "NCrv", "type": "uint16"})
+        p_ncrv.value = 0  # count not resolved directly -> falls back to legacy inference
+        p_npt = device.Point({"name": "NPt", "type": "uint16"})
+        p_npt.value = 2
+
+        class FakeModel:
+            pass
+
+        m = FakeModel()
+        m.model_id = 705
+        m.error_info = ''
+        m.add_error = lambda msg: None
+        m.NCrv = p_ncrv
+        m.NPt = p_npt
+        # 11 filler 1-register points bring the non-repeating point total to 13,
+        # matching the 13 non-repeating registers of model 705's top-level group
+        fillers = {'F%d' % i: device.Point({'name': 'F%d' % i, 'type': 'uint16'}) for i in range(11)}
+        m.points = {'NCrv': p_ncrv, 'NPt': p_npt, **fillers}
+        m.points_len = 13
+        m.groups = {}
+        m.len = 41  # 13 non-repeating + 28 repeating (2 curves x 14 registers each)
+
+        g = device.Group.__new__(device.Group)
+        g.model = m
+        g.gname = None
+        g.offset = 0
+        g.len = 0
+        g.points = {}
+        g.groups = {}
+        g.points_len = 0
+        g.group_class = device.Group
+        g.index = None
+        g.access_regions = None
+        g.gdef = None
+
+        groups = g._init_repeating_group(gdef=gdef_crv, model_offset=0, data=None, data_offset=0)
+        assert len(groups) == 2
+        for crv in groups:
+            assert crv.len == 14
+            assert crv.points_len == 10
+            assert len(crv.groups['Pt']) == 2
+
     def test_get_dict(self):
         gdata_705 = {
             "ID": 705,


### PR DESCRIPTION
Fixes #119

Group._init_repeating_group's legacy count-inference path (used when a repeating group's count can't be read directly from its count point, so the count is derived from total model length instead) divided by g.points_len, which only counts a group's own direct points and ignores any nested repeating subgroup.

This breaks models where a repeating group nests another repeating group, e.g. model 705's Crv group nesting a Pt group for curve points. With 2 curves of 2 points each, each Crv instance is actually 14 registers (10 own + 2×2 from Pt), but points_len reports only 10, so device.scan() raised ModelError: Repeating group count not consistent with model length for model 705, model repeating len = 28, model repeating group len = 10.

g.len is the fully-resolved length of one group instance including nested subgroups, and is the correct divisor. For groups with no nested subgroups g.len == g.points_len, so this is a no-op for the common case.

Added a regression test (test__init_repeating_group_legacy_count_nested_group) that reproduces the exact reported error against the old logic and passes against the fix.