### PR TITLE
Accept the length argument in eui48_to_data

### DIFF
--- a/sunspec2/mb.py
+++ b/sunspec2/mb.py
@@ -222,7 +222,7 @@ def str_to_data(s, slen=None):
     return struct.pack(str(slen) + 's', s)
 
 
-def eui48_to_data(eui48):
+def eui48_to_data(eui48, len=None):
     return (b'\x00\x00' + base64.b16decode(eui48.replace(':', '')))
 
 

--- a/sunspec2/tests/test_mb.py
+++ b/sunspec2/tests/test_mb.py
@@ -124,6 +124,27 @@ def test_str_to_data():
 def test_eui48_to_data():
     assert mb.eui48_to_data('12:34:56:78:90:AB') == b'\x00\x00\x12\x34\x56\x78\x90\xAB'
 
+def test_eui48_to_data_accepts_length():
+    # Point.get_mb() calls to_data(value, len * 2) for every type, so a to_data
+    # without the length parameter raises TypeError when reached that way.
+    assert mb.eui48_to_data('12:34:56:78:90:AB', 8) == mb.eui48_to_data('12:34:56:78:90:AB')
+
+
+def test_every_to_data_accepts_length():
+    # The uniform (value, len) signature is what Point.get_mb() relies on.
+    values = {
+        'int16': -1, 'uint16': 1, 'acc16': 1, 'enum16': 1, 'bitfield16': 1,
+        'int32': -1, 'uint32': 1, 'acc32': 1, 'enum32': 1, 'bitfield32': 1,
+        'int64': -1, 'uint64': 1, 'acc64': 1,
+        'ipaddr': 1, 'eui48': '12:34:56:78:90:AB',
+        'float32': 1.0, 'string': 'a', 'sunssf': 1, 'pad': 0,
+    }
+    for point_type, value in values.items():
+        info = mb.point_type_info[point_type]
+        # string has no fixed length; any even byte count will do here.
+        length = (info.len or 2) * 2
+        info.to_data(value, length)
+
 
 def test_is_impl_int16():
     assert not mb.is_impl_int16(-32768)


### PR DESCRIPTION
`eui48_to_data` is the only `*_to_data` in `sunspec2/mb.py` without the `len` parameter, but `Point.get_mb()` passes one to all of them:

```python
data = self.info.to_data(v, (int(self.len) * 2))
```

so serialising any point of type `eui48` raises:

```
TypeError: eui48_to_data() takes 1 positional argument but 2 were given
```

## Reproducing

Directly:

```python
import sunspec2.mb as mb

mb.point_type_info['eui48'].to_data('12:34:56:78:90:AB', 8)
# TypeError: eui48_to_data() takes 1 positional argument but 2 were given
```

Or through a device, which is how it tends to be met. `MAC` is defined by model 11 (Ethernet Link Layer) and model 16 (Simple IP Network), so `get_mb()` fails for any device implementing either:

```python
import sunspec2.file.client as fc

d = fc.FileClientDevice('some_device.json')   # a device whose models include 11 or 16
d.scan()
next(m for m in d.model_list if m.model_id == 11).get_mb()
# sunspec2.device.ModelError: Error getting point value MAC 00:40:AD:B0:A3:60:
#   eui48_to_data() takes 1 positional argument but 2 were given
```

I hit this while generating Modbus register images from a set of captured device files; every device reporting an Ethernet interface failed the same way.

## The change

One line in `sunspec2/mb.py`, matching the signature every neighbouring function already has:

```python
-def eui48_to_data(eui48):
+def eui48_to_data(eui48, len=None):
```

The value is fixed-width, so the argument is accepted and ignored exactly as `u16_to_data` and friends do.

## Why it went unnoticed

`test_eui48_to_data` calls it with a single argument, which works fine and always has. The failure only appears on the `get_mb()` path.

Two tests are added:

- `test_eui48_to_data_accepts_length` calls it the way `get_mb()` does.
- `test_every_to_data_accepts_length` walks `point_type_info` and calls every `to_data` with a length, so a future type added with the wrong signature fails here rather than at serialisation time.

Reverting the one-line fix fails both.

## Test results

| | result |
|---|---|
| `master` | 174 passed |
| this branch | 176 passed |

The difference is the two added tests; nothing else changes.

Three test modules are excluded from both runs — `test_modbus_client.py`, `test_modbus_modbus.py` and `test_tls_client.py` — and I should be clear that this is a fault in my environment rather than anything to do with this repository or with the change. I have an unrelated PyPI package named `serial` installed alongside `pyserial`; it shadows the `serial` module, and it pulls in `future`, which does `import imp`. That module was removed in Python 3.12, so those three fail at collection before any test runs. Removing the offending package is the fix, and it is mine to make.
