### PR TITLE
Write the float32 unimplemented value as its bit pattern

### DIFF
--- a/sunspec2/mb.py
+++ b/sunspec2/mb.py
@@ -91,6 +91,11 @@ def create_unimpl_value(vtype, len=None):
             raise ValueError('Unimplemented value creation for string requires a length')
     elif vtype == mdef.TYPE_IPV6ADDR:
         return b'\0' * 16
+    elif vtype == mdef.TYPE_FLOAT32:
+        # SUNS_UNIMPL_FLOAT32 is a bit pattern, not a quantity. Passing it to
+        # f32_to_data encodes the number 2143289344.0 instead, which reads back
+        # as an ordinary value rather than as an unimplemented point.
+        return struct.pack('>I', SUNS_UNIMPL_FLOAT32)
     return point_type_info[vtype][3](value)
 
 

--- a/sunspec2/tests/test_mb.py
+++ b/sunspec2/tests/test_mb.py
@@ -1,3 +1,5 @@
+import struct
+
 import sunspec2.mb as mb
 import pytest
 
@@ -25,10 +27,23 @@ def test_create_unimpl_value():
     assert mb.create_unimpl_value('int64') == b'\x80\x00\x00\x00\x00\x00\x00\x00'
     assert mb.create_unimpl_value('uint64') == b'\xff\xff\xff\xff\xff\xff\xff\xff'
     assert mb.create_unimpl_value('acc64') == b'\x00\x00\x00\x00\x00\x00\x00\x00'
-    assert mb.create_unimpl_value('float32') == b'N\xff\x80\x00'
+    assert mb.create_unimpl_value('float32') == b'\x7f\xc0\x00\x00'
     assert mb.create_unimpl_value('sunssf') == b'\x80\x00'
     assert mb.create_unimpl_value('eui48') == b'\x00\x00\xff\xff\xff\xff\xff\xff'
     assert mb.create_unimpl_value('pad') == b'\x00\x00'
+
+def test_create_unimpl_value_float32_is_the_sentinel_bit_pattern():
+    # SUNS_UNIMPL_FLOAT32 is a bit pattern. Encoded as a quantity it becomes
+    # 2143289344.0, which reads back as an ordinary value rather than as absent.
+    data = mb.create_unimpl_value('float32', len=4)
+    assert data == struct.pack('>I', mb.SUNS_UNIMPL_FLOAT32)
+    assert data != struct.pack('>f', float(mb.SUNS_UNIMPL_FLOAT32))
+
+
+def test_unimpl_float32_round_trips_to_none():
+    # The reader already maps the NaN pattern to None; this is what lets the
+    # writer meet it.
+    assert mb.data_to_f32(mb.create_unimpl_value('float32', len=4)) is None
 
 
 def test_data_to_s16():


### PR DESCRIPTION
`SUNS_UNIMPL_FLOAT32` is `0x7fc00000` — a bit pattern, the canonical quiet NaN. But `create_unimpl_value` hands it to `f32_to_data`, which packs it as a *quantity*:

```python
>>> import sunspec2.mb as mb
>>> mb.create_unimpl_value('float32', len=4).hex()
'4eff8000'
```

`0x4EFF8000` is `struct.pack('>f', 2143289344.0)`. So a point recorded as unimplemented is serialised as the perfectly ordinary number 2143289344.0, which a reader cannot distinguish from a measurement.

## Consequence

The bytes on the wire are wrong for any reader that decodes them per the spec. Model 113 is a good example, since its temperatures are `float32` and are frequently unimplemented:

```python
import sunspec2.file.client as fc

d = fc.FileClientDevice('device.json')   # TmpSnk recorded as null
d.scan()
m = next(x for x in d.model_list if x.model_id == 113)

m.get_dict()['TmpSnk']                   # None, correct
mb.data_to_f32(m.get_mb()[...])          # 2143289344.0, not None
```

I met this comparing an independent decoder against this library across a set of captured devices: every unimplemented `float32` came back as 2143289344.0 from the serialised registers while `get_dict()` reported `None` for the same point.

## The reader was always right

`data_to_f32` already maps the NaN pattern to `None`:

```python
def data_to_f32(data):
    f = struct.unpack('>f', data[:4])
    if str(f[0]) != str(float('nan')):
        return f[0]
```

So this is the writer disagreeing with the reader, not an ambiguity about what the sentinel means. Packing the bit pattern lets the two meet.

## Consistency

Every other type in `create_unimpl_value` already emits its sentinel's bits — `int16` → `80 00`, `uint16` → `ff ff`, `acc32` → `00 00 00 00`, and so on. `float32` is the only one that encodes the sentinel as a value first. The change brings it into line:

```python
+    elif vtype == mdef.TYPE_FLOAT32:
+        return struct.pack('>I', SUNS_UNIMPL_FLOAT32)
```

## A changed assertion

`test_create_unimpl_value` pinned the old bytes:

```python
-    assert mb.create_unimpl_value('float32') == b'N\xff\x80\x00'
+    assert mb.create_unimpl_value('float32') == b'\x7f\xc0\x00\x00'
```

Flagging that explicitly since it is an existing test changing rather than a new one passing. Two tests are added alongside it: that the bytes are the sentinel pattern and specifically *not* the quantity, and that an unimplemented `float32` now round-trips back to `None`. Both fail without the change.

## Test results

| | result |
|---|---|
| `master` | 174 passed |
| this branch | 176 passed |

Three test modules are excluded from both runs (`test_modbus_client.py`, `test_modbus_modbus.py`, `test_tls_client.py`). That is a fault in my environment, not this repository: I have an unrelated PyPI package named `serial` shadowing `pyserial`, and it pulls in `future`, which does `import imp` — removed in Python 3.12 — so those three fail at collection.

## Related, not changed here

`create_unimpl_value('float64')` raises `struct.error`: `SUNS_UNIMPL_FLOAT64` exists but `float64` has no entry in `unimpl_value`, so `None` reaches `f64_to_data`. No bundled model uses `float64`, so I have left it alone rather than widen this change, but it looks like the same root cause and you may want it.

---

**Maintainer note (edited into this description):** the sentence above originally read "a device file with an absent `float32` no longer round-trips". That claim is too broad, so it has been narrowed to the encoding. The library's own round-trip was never broken: `data_to_f32(b'N\xff\x80\x00')` returns `2143289344.0`, which is exactly `SUNS_UNIMPL_FLOAT32`, so `is_impl_float32` rejects it and `set_mb` sets the point to `None`. Checked at the device level on both sides of the change:

```
master:      unimpl float32 bytes: 4eff8000 -> data_to_f32: 2143289344.0 -> after set_mb, value = None
this branch: unimpl float32 bytes: 7fc00000 -> data_to_f32: None         -> after set_mb, value = None
```

The defect is confined to the encoding, which is still worth fixing for exactly the reason the description opens with: an external, spec-conformant reader sees a measurement where there is none.

The same mechanism means read compatibility is preserved by this change, which is the question a reviewer is most likely to ask: register images written by earlier versions still decode as unimplemented.

Revert this block if you would rather state it differently.
